### PR TITLE
Fix search label placeholders

### DIFF
--- a/wp-content/plugins/features-by-woothemes/classes/class-woothemes-features.php
+++ b/wp-content/plugins/features-by-woothemes/classes/class-woothemes-features.php
@@ -83,7 +83,7 @@ class Woothemes_Features {
 			'new_item' => sprintf( __( 'New %s', 'woothemes-features' ), __( 'Feature', 'woothemes-features' ) ),
 			'all_items' => sprintf( __( 'All %s', 'woothemes-features' ), __( 'Features', 'woothemes-features' ) ),
 			'view_item' => sprintf( __( 'View %s', 'woothemes-features' ), __( 'Feature', 'woothemes-features' ) ),
-			'search_items' => sprintf( __( 'Search %a', 'woothemes-features' ), __( 'Features', 'woothemes-features' ) ),
+                        'search_items' => sprintf( __( 'Search %s', 'woothemes-features' ), __( 'Features', 'woothemes-features' ) ),
 			'not_found' =>  sprintf( __( 'No %s Found', 'woothemes-features' ), __( 'Features', 'woothemes-features' ) ),
 			'not_found_in_trash' => sprintf( __( 'No %s Found In Trash', 'woothemes-features' ), __( 'Features', 'woothemes-features' ) ),
 			'parent_item_colon' => '',

--- a/wp-content/plugins/features-by-woothemes/lang/woothemes-features-en_GB.po
+++ b/wp-content/plugins/features-by-woothemes/lang/woothemes-features-en_GB.po
@@ -92,7 +92,7 @@ msgstr ""
 #: classes/class-woothemes-features.php:86
 #, php-format
 #@ woothemes-features
-msgid "Search %a"
+msgid "Search %s"
 msgstr ""
 
 #: classes/class-woothemes-features.php:87

--- a/wp-content/plugins/testimonials-by-woothemes/classes/class-woothemes-testimonials.php
+++ b/wp-content/plugins/testimonials-by-woothemes/classes/class-woothemes-testimonials.php
@@ -81,7 +81,7 @@ class Woothemes_Testimonials {
 			'new_item' => sprintf( __( 'New %s', 'woothemes-testimonials' ), __( 'Testimonial', 'woothemes-testimonials' ) ),
 			'all_items' => sprintf( __( 'All %s', 'woothemes-testimonials' ), __( 'Testimonials', 'woothemes-testimonials' ) ),
 			'view_item' => sprintf( __( 'View %s', 'woothemes-testimonials' ), __( 'Testimonial', 'woothemes-testimonials' ) ),
-			'search_items' => sprintf( __( 'Search %a', 'woothemes-testimonials' ), __( 'Testimonials', 'woothemes-testimonials' ) ),
+                        'search_items' => sprintf( __( 'Search %s', 'woothemes-testimonials' ), __( 'Testimonials', 'woothemes-testimonials' ) ),
 			'not_found' =>  sprintf( __( 'No %s Found', 'woothemes-testimonials' ), __( 'Testimonials', 'woothemes-testimonials' ) ),
 			'not_found_in_trash' => sprintf( __( 'No %s Found In Trash', 'woothemes-testimonials' ), __( 'Testimonials', 'woothemes-testimonials' ) ),
 			'parent_item_colon' => '',

--- a/wp-content/plugins/testimonials-by-woothemes/lang/testimonials-by-woothemes.pot
+++ b/wp-content/plugins/testimonials-by-woothemes/lang/testimonials-by-woothemes.pot
@@ -109,7 +109,7 @@ msgid "View %s"
 msgstr ""
 
 #: classes/class-woothemes-testimonials.php:84
-msgid "Search %a"
+msgid "Search %s"
 msgstr ""
 
 #: classes/class-woothemes-testimonials.php:85

--- a/wp-content/plugins/testimonials-by-woothemes/lang/woothemes-testimonials-en_GB.po
+++ b/wp-content/plugins/testimonials-by-woothemes/lang/woothemes-testimonials-en_GB.po
@@ -92,7 +92,7 @@ msgstr ""
 #: classes/class-woothemes-testimonials.php:84
 #, php-format
 #@ woothemes-testimonials
-msgid "Search %a"
+msgid "Search %s"
 msgstr ""
 
 #: classes/class-woothemes-testimonials.php:85


### PR DESCRIPTION
## Summary
- fix placeholder in Features label to use `%s`
- fix Testimonials label placeholder
- update translation messages

## Testing
- `php -l wp-content/plugins/features-by-woothemes/classes/class-woothemes-features.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f7cdba6f08332844a51bdfacc5713