### PR TITLE
Add basic testimonials test

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,8 @@ Proyecto Marketplace de clases de guitarra MVP
 
 [] probando las tareas
 [ ] probando las tareas
+
+## Running Tests
+
+1. Install the WordPress testing suite (e.g., using `wp scaffold plugin-tests` or by manually checking out the `wordpress-develop` tests library).
+2. From the repository root run `phpunit`.

--- a/tests/testimonials_test.php
+++ b/tests/testimonials_test.php
@@ -1,0 +1,28 @@
+<?php
+class Testimonials_Test extends WP_UnitTestCase {
+    public static function wpSetUpBeforeClass( $factory ) {
+        if ( ! class_exists( 'Woothemes_Testimonials' ) ) {
+            require dirname( __DIR__ ) . '/wp-content/plugins/testimonials-by-woothemes/woothemes-testimonials.php';
+        }
+        // Ensure the post type is registered for the tests.
+        global $woothemes_testimonials;
+        if ( isset( $woothemes_testimonials ) ) {
+            $woothemes_testimonials->register_post_type();
+            $woothemes_testimonials->register_taxonomy();
+        }
+    }
+
+    public function test_get_testimonials_returns_array_when_entries_exist() {
+        // Create a testimonial post.
+        self::factory()->post->create( array(
+            'post_type'   => 'testimonial',
+            'post_status' => 'publish',
+        ) );
+
+        $testimonials = woothemes_get_testimonials();
+
+        $this->assertIsArray( $testimonials );
+        $this->assertNotEmpty( $testimonials );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add WordPress unit test for WooThemes testimonials
- document how to run the PHPUnit suite

## Testing
- `phpunit tests/testimonials_test.php` *(fails: Class "WP_UnitTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f88a9b9dc8332aab6f96055095a01