### PR TITLE
Fix typo in shortcode generator comments

### DIFF
--- a/wp-content/themes/theonepager101/functions/admin-shortcode-generator.php
+++ b/wp-content/themes/theonepager101/functions/admin-shortcode-generator.php
@@ -135,7 +135,7 @@ function framework_url() {
   * Returns JSON.
   *
   * NOTE: For users that are not logged in this is not called.
-  * The client recieves <code>-1</code> in that case.
+  * The client receives <code>-1</code> in that case.
 -----------------------------------------------------------------------------------*/
 
 function ajax_action_check_url() {
@@ -161,7 +161,7 @@ function ajax_action_check_url() {
   * Generate a nonce.
   *
   * NOTE: For users that are not logged in this is not called.
-  * The client recieves <code>-1</code> in that case.
+  * The client receives <code>-1</code> in that case.
 -----------------------------------------------------------------------------------*/
 
 function ajax_action_generate_nonce() {


### PR DESCRIPTION
## Summary
- correct `recieves` typo in comments

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f88a85de883328c6349b813cb6c2f